### PR TITLE
Copy keystat.env into $(env)/keystat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ $(unit)/keystat.service: keystat.service $(unit)
 	cp -p $< $@
 
 $(env)/keystat: keystat.env $(env)
+	cp -p $< $@
 
 $(bin):
 	mkdir -p $@


### PR DESCRIPTION
When running `make install` the `keystat.env` was not copied.
