### PR TITLE
Reimplemented translate.py to use users keymap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ env             := $(DESTDIR)/etc/default
 install: \
 	$(bin)/keystat-capture \
 	$(bin)/keystat-dump \
-	$(bin)/keystat-translate \
+	$(bin)/keystat-translate.lua \
+	$(bin)/keystat-translate.py \
 	$(unit)/keystat.service \
 	$(env)/keystat
 
@@ -38,7 +39,10 @@ $(bin)/keystat-capture: capture $(bin)
 $(bin)/keystat-dump: dump $(bin)
 	cp -p $< $@
 
-$(bin)/keystat-translate: translate.lua $(bin)
+$(bin)/keystat-translate.lua: translate.lua $(bin)
+	cp -p $< $@
+
+$(bin)/keystat-translate.py: translate.py $(bin)
 	cp -p $< $@
 
 $(unit)/keystat.service: keystat.service $(unit)

--- a/translate.py
+++ b/translate.py
@@ -3,12 +3,21 @@
 import subprocess
 import sys
 import re
+import argparse
 
-if len(sys.argv) >= 2:
+parser = argparse.ArgumentParser(description='Process some integers.')
+parser.add_argument('--keymap-source', dest='source', choices=["linux/input.h","xmodmap"],
+                   default="xmodmap",help='specify which keymap to use')
+parser.add_argument('--dumpfile', type=str, dest="dumpfile",
+                   help='the path to the dumpfile, if not specified stdin will be used')
+args = parser.parse_args()
+
+
+if args.dumpfile:
     try:
-        dump = open(sys.argv[1])
+        dump = open(args.dumpfile)
     except:
-        print("usage: %s <filename>"%sys.argv[0])
+        print("%s is not readable or does not exist."%args.dumpfile)
         sys.exit(1)
 else:
     dump = sys.stdin
@@ -38,13 +47,14 @@ def cmd_exists(cmd): # from http://stackoverflow.com/a/11069822/3890934
     return subprocess.call("type " + cmd, shell=True,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
 
-if cmd_exists("xmodmap"):
-    try:
-        mapping = load_mapping_from_xmodmap()
-    except:
-        mapping = load_mapping_from_linux_input_h()
-else:
+if args.source == "linux/input.h":
     mapping = load_mapping_from_linux_input_h()
+elif args.source == "xmodmap":
+    if cmd_exists("xmodmap"):
+        try:
+            mapping = load_mapping_from_xmodmap()
+        except:
+            print("Could not load mapping from xmodmap.")
 
 table = []
 

--- a/translate.py
+++ b/translate.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import subprocess
+import sys
+positions_to_translate = [0,1,2]
+offset = -8
+keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
+mapping = {}
+for line in keymap.split("\n"):
+	parts = line.split()
+	if len(parts) > 4:
+		mapping[int(parts[1])+offset] = parts[3]
+table = []
+for line in sys.stdin:
+	parts = line.split()
+	if int(parts[3]) > 0:
+		for position in positions_to_translate:
+			parts[position] = mapping[int(parts[position])]
+		table.append(parts)
+
+table.sort(key=lambda x: int(x[3]), reverse=True)
+for row in table:
+	print(" ".join(row))
+#1,3

--- a/translate.py
+++ b/translate.py
@@ -2,7 +2,14 @@
 # -*- coding: utf-8 -*-
 import subprocess
 import sys
-
+if len(sys.argv) >= 2:
+    try:
+        dump = open(sys.argv[1])
+    except:
+        print("usage: %s <filename>"%sys.argv[0])
+        sys.exit(1)
+else:
+    dump = sys.stdin
 positions_to_translate = [0,1,2]
 offset = -8
 keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
@@ -15,7 +22,7 @@ for line in keymap.split("\n"):
 
 table = []
 
-for line in sys.stdin:
+for line in dump:
     parts = line.split()
     if int(parts[3]) > 0:
         for position in positions_to_translate:

--- a/translate.py
+++ b/translate.py
@@ -9,20 +9,23 @@ keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
 mapping = {}
 
 for line in keymap.split("\n"):
-	parts = line.split()
-	if len(parts) > 4:
-		mapping[int(parts[1])+offset] = parts[3]
+    parts = line.split()
+    if len(parts) > 4:
+        mapping[int(parts[1])+offset] = parts[3]
 
 table = []
 
 for line in sys.stdin:
-	parts = line.split()
-	if int(parts[3]) > 0:
-		for position in positions_to_translate:
-			parts[position] = mapping[int(parts[position])]
-		table.append(parts)
+    parts = line.split()
+    if int(parts[3]) > 0:
+        for position in positions_to_translate:
+            parts[position] = mapping[int(parts[position])]
+        table.append(parts)
 
 table.sort(key=lambda x: int(x[3]), reverse=True)
 
 for row in table:
-	print(" ".join(row))
+    try:
+        print(" ".join(row))
+    except Exception:
+        break

--- a/translate.py
+++ b/translate.py
@@ -55,6 +55,7 @@ elif args.source == "xmodmap":
             mapping = load_mapping_from_xmodmap()
         except:
             print("Could not load mapping from xmodmap.")
+            sys.exit(1)
 
 table = []
 

--- a/translate.py
+++ b/translate.py
@@ -2,15 +2,19 @@
 # -*- coding: utf-8 -*-
 import subprocess
 import sys
+
 positions_to_translate = [0,1,2]
 offset = -8
 keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
 mapping = {}
+
 for line in keymap.split("\n"):
 	parts = line.split()
 	if len(parts) > 4:
 		mapping[int(parts[1])+offset] = parts[3]
+
 table = []
+
 for line in sys.stdin:
 	parts = line.split()
 	if int(parts[3]) > 0:
@@ -19,6 +23,6 @@ for line in sys.stdin:
 		table.append(parts)
 
 table.sort(key=lambda x: int(x[3]), reverse=True)
+
 for row in table:
 	print(" ".join(row))
-#1,3

--- a/translate.py
+++ b/translate.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 import subprocess
 import sys
+import re
+
 if len(sys.argv) >= 2:
     try:
         dump = open(sys.argv[1])
@@ -10,15 +12,39 @@ if len(sys.argv) >= 2:
         sys.exit(1)
 else:
     dump = sys.stdin
+
 positions_to_translate = [0,1,2]
 offset = -8
-keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
-mapping = {}
 
-for line in keymap.split("\n"):
-    parts = line.split()
-    if len(parts) > 4:
-        mapping[int(parts[1])+offset] = parts[3]
+def load_mapping_from_xmodmap():
+    keymap = subprocess.check_output(["xmodmap","-pke"]).decode("utf-8")
+    mapping = {}
+
+    for line in keymap.split("\n"):
+        parts = line.split()
+        if len(parts) > 4:
+            mapping[int(parts[1])+offset] = parts[3]
+    return mapping
+def load_mapping_from_linux_input_h():
+    mapping = {}
+    with open("/usr/include/linux/input.h") as headerfile:
+        regex = "^#define KEY_([^\s]*)\s*(\d*)"
+        finds = re.findall(regex, headerfile.read(), flags=re.MULTILINE)
+        for keyname, scancode in finds:
+            if keyname and scancode:
+                mapping[int(scancode)] = keyname
+    return mapping
+def cmd_exists(cmd): # from http://stackoverflow.com/a/11069822/3890934
+    return subprocess.call("type " + cmd, shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
+
+if cmd_exists("xmodmap"):
+    try:
+        mapping = load_mapping_from_xmodmap()
+    except:
+        mapping = load_mapping_from_linux_input_h()
+else:
+    mapping = load_mapping_from_linux_input_h()
 
 table = []
 


### PR DESCRIPTION
Translate.lua can only use "linux/input.h". I can't programm in lua, therefor I rebuild translate.lua in python. This version uses "xmodmap -pke" to get the users keymap. It can be used as a drop-in replacement for translate.lua.
