### PR TITLE
Set correct map-path in keystat.env

### DIFF
--- a/keystat.env
+++ b/keystat.env
@@ -1,2 +1,2 @@
-KEYSTAT_MAP="/var/lib/keystat"
+KEYSTAT_MAP="/var/lib/keystat/map"
 KEYSTAT_DEV="/dev/input/by-path/platform-i8042-serio-0-event-kbd"


### PR DESCRIPTION
The readme says /var/lib/keystat/map, so it should be also used by keystat.env
